### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tools for parsing annual school report card data from the state of Illinois
 * [GNU Make](https://www.gnu.org/software/make/)
 * [GNU Wget](https://www.gnu.org/software/wget/)
 * [Python 3](https://www.python.org/downloads/)
-* [csvkit](https://csvkit.readthedocs.org/en/latest/install.html)
+* [csvkit](https://csvkit.readthedocs.io/en/latest/tutorial/1_getting_started.html#installing-csvkit)
 * [xlsx2csv](https://github.com/dilshod/xlsx2csv)
 * [PostgreSQL](http://www.postgresql.org/)
 * [unzip](http://www.info-zip.org/)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
